### PR TITLE
Fix subsequent showing of profile view

### DIFF
--- a/gapic/src/main/com/google/gapid/perfetto/views/State.java
+++ b/gapic/src/main/com/google/gapid/perfetto/views/State.java
@@ -323,7 +323,7 @@ public abstract class State {
 
   private void update() {
     nanosPerPx = visibleTime.getDuration() / width;
-    if (nanosPerPx <= 0) {
+    if (width <= 0 || nanosPerPx <= 0) {
       nanosPerPx = 0;
       resolution = 0;
     } else {

--- a/gapic/src/main/com/google/gapid/views/ProfileView.java
+++ b/gapic/src/main/com/google/gapid/views/ProfileView.java
@@ -97,6 +97,7 @@ public class ProfileView extends Composite implements Tab, Capture.Listener, Pro
   @Override
   public void reinitialize() {
     if (models.profile.isLoaded()) {
+      loading.stopLoading();
       updateProfile(models.profile.getData());
     } else {
       loading.showMessage(


### PR DESCRIPTION
There were two issues here:

 * There is a transient state where the width is zero, before everything
   has been sized properly. This caused the visible exception

 * If the profile model was already available at the point the panel is
   created, then we would never hide the 'loading' overlay widgets, so
   they would obscure the actual profile view forever